### PR TITLE
Sprockets only with folder fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,10 @@ add `activate :emblem` to config.rb
 ## Configuration
 
 by default
-    
-    set :emblem_dir, "emblem_templates"
-    set :emblem_ext, "emblem"
+    activate :emblem, emblem_dir: "templates", :emblem_ext, "emblem"
 
 but this can be changed in config.rb to something like
-
-    set :emblem_dir, "templates_haml"
-    set :emblem_ext, "haml"
+    activate :emblem, emblem_dir: "templates_haml", :emblem_ext, "haml"
 
 ## Contributing
 

--- a/lib/middleman-emblem/extension.rb
+++ b/lib/middleman-emblem/extension.rb
@@ -1,51 +1,22 @@
-
-
+require "barber-emblem"
+require_relative "sprockets-template"
 
 module Middleman
   module Emblem
     class << self
+      @@template_root = "templates"
+
+      def template_root
+        @@template_root
+      end
+
       def registered(app, options={})
-        require "barber-emblem"
-        require "#{File.dirname(__FILE__)}/sprockets-template"
-
-
-
-
+        sprocket_extension = "emblem"
         app.after_configuration do
-          
-          set :emblem_ext, "emblem" if emblem_ext.nil?
-          set :emblem_dir, "emblem_templates" if emblem_ext.nil?
-
-          
-
-
-
-
-
-          ::Sprockets.register_engine ".#{emblem_ext}", Middleman::Emblem::Template
-          spenv = ::Sprockets::Environment.new(root)
-          spenv.append_path("#{source_dir}/#{emblem_dir}");
-
-          #truncate output file
-          File.open("#{source_dir}/app/templates.js", 'w') {|f| f.write("")}
-
-          c = 0
-          Dir["#{source_dir}/#{emblem_dir}/**/*.#{emblem_ext}"].each do |f|
-            ignore sitemap.file_to_path(f)
-            local_name = f.gsub("#{source_dir}/#{emblem_dir}/", "");
-            template = spenv[local_name].to_s
-            puts "   \e[1m\e[33m[emblem]\e[22m compiling \e[0m #{local_name}"
-
-
-
-            basename = local_name.gsub(".#{emblem_ext}", "")
-            File.open("#{source_dir}/app/templates.js", 'a') {|f| f.write(template + "\r\n") }
-            c += 1
-          end
-          puts "   \e[1m\e[33m[emblem]\e[22m compiled \e[1m\e[0m#{c} \e[22m\e[33mtemplates to \e[1m\e[0msource/app/templates.js\e[22m"
-
+          @@template_root    = options[:emblem_dir] if options.has_key?(:emblem_dir)
+          sprocket_extension = options[:emblem_ext] if options.has_key?(:emblem_ext)
+          ::Sprockets.register_engine ".#{sprocket_extension}", Middleman::Emblem::Template
         end
-
       end  
       alias :included :registered
     end

--- a/lib/middleman-emblem/sprockets-template.rb
+++ b/lib/middleman-emblem/sprockets-template.rb
@@ -3,7 +3,6 @@ require 'sprockets/engines'
 require 'barber-emblem'
 require 'barber'
 
-
 module Middleman
   module Emblem
     class Template < Tilt::Template
@@ -20,11 +19,34 @@ module Middleman
 
       private
 
-
       def template_target(scope)
-        "Ember.TEMPLATES[#{scope.logical_path.inspect}]"
+        "Ember.TEMPLATES[#{template_path(scope.logical_path).inspect}]"
       end
 
+      def template_path(path)
+        root = configuration.templates_root
+
+        if root.kind_of? Array
+          root.each do |root|
+            path.sub!(/#{Regexp.quote(root)}\//, '')
+          end
+        else
+          unless root.empty?
+            path.sub!(/#{Regexp.quote(root)}\/?/, '')
+          end
+        end
+
+        path = path.split('/')
+
+        path.join(configuration.templates_path_separator)
+      end
+
+      def configuration
+        OpenStruct.new(
+          templates_root: Middleman::Emblem.template_root,
+          templates_path_separator: "/"
+        )
+      end
 
       def precompile_ember_emblem(string)
         Barber::Emblem::EmberFilePrecompiler.call(string)


### PR DESCRIPTION
@j-mcnally Here's a PR that removes the write out to app/template.js and also removes the root folder from the name of the Emblem templates. 

I've also updated the README to indicate the revised format for configuration.
