### PR TITLE
Revise for middleman 3 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple plugin to support emblem with Middleman
 
 Inspired by https://github.com/GutenYe/middleman-ember-template
 
-A great template but we wanted to add haml style support for ember templates.
+A great template but we wanted to add slim style support for ember templates.
 
 Built around the Emblem JS project: https://github.com/machty/emblem.js
 
@@ -28,11 +28,15 @@ add `activate :emblem` to config.rb
 
 ## Configuration
 
-by default
-    activate :emblem, emblem_dir: "templates", :emblem_ext, "emblem"
+by default:
+`activate :emblem, emblem_dir: "templates", emblem_ext: "emblem", ignore: true`
 
-but this can be changed in config.rb to something like
-    activate :emblem, emblem_dir: "templates_haml", :emblem_ext, "haml"
+`ignore: true` means it will ignore the "templates" folder when building
+
+but this can be changed in config.rb to something like:
+`activate :emblem, emblem_dir: "templates_slim", emblem_ext: "slim", ignore: false`
+
+`ignore: false` means you need to *explicity ignore* the "templates" folder in your config.rb when building
 
 ## Contributing
 

--- a/lib/middleman-emblem/extension.rb
+++ b/lib/middleman-emblem/extension.rb
@@ -12,11 +12,10 @@ module Middleman
 
       def registered(app, options={})
         sprocket_extension = "emblem"
+        @@template_root    = options[:emblem_dir] if options.has_key?(:emblem_dir)
+        sprocket_extension = options[:emblem_ext] if options.has_key?(:emblem_ext)
+        ::Sprockets.register_engine ".#{sprocket_extension}", Middleman::Emblem::Template
         app.after_configuration do
-          @@template_root    = options[:emblem_dir] if options.has_key?(:emblem_dir)
-          sprocket_extension = options[:emblem_ext] if options.has_key?(:emblem_ext)
-          ignore "#{js_dir}/#{@@template_root}*"
-          ::Sprockets.register_engine ".#{sprocket_extension}", Middleman::Emblem::Template
         end
       end  
       alias :included :registered

--- a/lib/middleman-emblem/extension.rb
+++ b/lib/middleman-emblem/extension.rb
@@ -16,6 +16,7 @@ module Middleman
         sprocket_extension = options[:emblem_ext] if options.has_key?(:emblem_ext)
         ::Sprockets.register_engine ".#{sprocket_extension}", Middleman::Emblem::Template
         app.after_configuration do
+          ignore "#{js_dir}/#{@@template_root}*" unless options.has_key?(:ignore) && !options[:ignore] 
         end
       end  
       alias :included :registered


### PR DESCRIPTION
@j-mcnally This PR moves the logic for registering the Sprockets engine out of the #after_configuration block as otherwise it doesn't work with Middleman 3.1.beta.

I've also added another option to allow you to _not_ ignore the templates folder, if you want to be explicit by ignoring it yourself. The default is still to ignore it.

This works well for me with the Middleman 3.1 branch and still works under 3.0.x as well.
